### PR TITLE
Set nofile ulimit to fix dante startup issues.

### DIFF
--- a/docker-compose-dist.yml
+++ b/docker-compose-dist.yml
@@ -38,6 +38,9 @@ services:
       - CRON="*/10 * * * *" # empty to disable server's load check and display.
     secrets:
       - NORDVPN_CREDS
+    # Work around for https://github.com/edgd1er/nordvpn-proxy/issues/38
+    ulimits:
+      nofile: 262144
 
 secrets:
   NORDVPN_CREDS:


### PR DESCRIPTION
Fixes https://github.com/edgd1er/nordvpn-proxy/issues/38

(Sorry the unrelated new line at the end. GitHub's built-in editor wanted it that way).